### PR TITLE
Use published @kixelated packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.0.1",
       "dependencies": {
         "@huggingface/transformers": "^3.7.2",
-        "@kixelated/hang": "file:../moq/js/hang",
+        "@kixelated/hang": "^0.5.0",
         "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
-        "@kixelated/moq": "file:../moq/js/moq",
-        "@kixelated/signals": "file:../moq/js/signals",
+        "@kixelated/moq": "^0.9.1",
+        "@kixelated/signals": "^0.7.0",
         "@kixelated/web-transport-ws": "^0.1.2",
         "@libav.js/variant-opus-af": "^6.8.8",
         "async-mutex": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^3.7.2",
-    "@kixelated/hang": "file:../moq/js/hang",
+    "@kixelated/hang": "^0.5.0",
     "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
-    "@kixelated/moq": "file:../moq/js/moq",
-    "@kixelated/signals": "file:../moq/js/signals",
+    "@kixelated/moq": "^0.9.1",
+    "@kixelated/signals": "^0.7.0",
     "@kixelated/web-transport-ws": "^0.1.2",
     "@libav.js/variant-opus-af": "^6.8.8",
     "async-mutex": "^0.5.0",

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -10,13 +10,6 @@ log() {
 cd "${PROJECT_ROOT}"
 
 log "Installing npm dependencies"
-npm_config_yes=${npm_config_yes:-}
-
-if [[ ! -d "${PROJECT_ROOT}/../moq" ]]; then
-  log "Cloning kixelated/moq dependencies"
-  git clone --depth 1 https://github.com/kixelated/moq.git "${PROJECT_ROOT}/../moq"
-fi
-
 npm ci
 
 log "Installing Playwright browsers"


### PR DESCRIPTION
## Summary
- switch the @kixelated dependencies from local `file:` paths to the published npm releases
- refresh the lockfile so installs no longer depend on a sibling `moq` checkout

## Testing
- npm run build
- npm run test:e2e
- nix run .#ci (pass)