### PR TITLE
Add onboarding step for meeting name

### DIFF
--- a/src/onboarding.tsx
+++ b/src/onboarding.tsx
@@ -1,0 +1,113 @@
+import { createSignal, onCleanup, onMount, type Component } from "solid-js";
+
+const ADJECTIVES = [
+  "bright",
+  "calm",
+  "clever",
+  "cozy",
+  "gentle",
+  "keen",
+  "lively",
+  "quick",
+  "sunny",
+  "vivid",
+] as const;
+
+const NOUNS = [
+  "conversation",
+  "gathering",
+  "huddle",
+  "meeting",
+  "moment",
+  "session",
+  "standup",
+  "sync",
+  "talk",
+  "workshop",
+] as const;
+
+function pick<T>(items: readonly T[]): T {
+  return items[Math.floor(Math.random() * items.length)]!;
+}
+
+function generateMeetingName(): string {
+  return `${pick(ADJECTIVES)}-${pick(NOUNS)}`;
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/[\s_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export const Onboarding: Component = () => {
+  const [name, setName] = createSignal(generateMeetingName());
+
+  onMount(() => {
+    document.body.classList.add("onboarding");
+  });
+
+  onCleanup(() => {
+    document.body.classList.remove("onboarding");
+  });
+
+  const startMeeting = () => {
+    const meeting = slugify(name());
+    if (!meeting) return;
+
+    const url = new URL(window.location.href);
+    url.pathname = `/${meeting}`;
+    url.searchParams.delete("room");
+    window.location.href = url.toString();
+  };
+
+  const regenerate = () => {
+    setName(generateMeetingName());
+  };
+
+  const handleSubmit = (event: SubmitEvent) => {
+    event.preventDefault();
+    startMeeting();
+  };
+
+  return (
+    <main class="onboarding__container">
+      <section class="onboarding__card">
+        <header class="onboarding__header">
+          <h1>Start a meeting</h1>
+          <p>Pick a name or use the suggested one below.</p>
+        </header>
+
+        <form class="onboarding__form" onSubmit={handleSubmit}>
+          <label class="onboarding__label" for="meeting-name">
+            Meeting name
+          </label>
+          <input
+            id="meeting-name"
+            class="onboarding__input"
+            type="text"
+            autocomplete="off"
+            value={name()}
+            onInput={(event) => setName(event.currentTarget.value)}
+            required
+          />
+
+          <div class="onboarding__actions">
+            <button type="button" class="onboarding__secondary" onClick={regenerate}>
+              Generate another
+            </button>
+            <button type="submit" class="onboarding__primary">
+              Start meeting
+            </button>
+          </div>
+        </form>
+      </section>
+    </main>
+  );
+};
+
+export { generateMeetingName };

--- a/src/style.css
+++ b/src/style.css
@@ -15,6 +15,104 @@ body {
   background: radial-gradient(circle at top, rgba(148, 163, 184, 0.2), transparent 55%), #020617;
 }
 
+body.onboarding {
+  background: #f8fafc;
+  color: #0f172a;
+  padding: 0;
+}
+
+.onboarding__container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  min-height: 100vh;
+  background: #f8fafc;
+  padding: 1.5rem;
+}
+
+.onboarding__card {
+  width: min(560px, 100%);
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 2.5rem;
+  box-shadow: 0 25px 60px rgba(15, 23, 42, 0.08);
+  border: 1px solid #e2e8f0;
+  display: grid;
+  gap: 1.75rem;
+}
+
+.onboarding__header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.onboarding__header p {
+  margin: 0;
+  color: #475569;
+}
+
+.onboarding__form {
+  display: grid;
+  gap: 1rem;
+}
+
+.onboarding__label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.onboarding__input {
+  border: 1px solid #cbd5f5;
+  border-radius: 0.75rem;
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.onboarding__input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.onboarding__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.onboarding__primary,
+.onboarding__secondary {
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  padding: 0.75rem 1.5rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.onboarding__primary {
+  background: #2563eb;
+  color: #fff;
+}
+
+.onboarding__secondary {
+  background: #e2e8f0;
+  color: #1e293b;
+}
+
+.onboarding__primary:hover,
+.onboarding__secondary:hover,
+.onboarding__primary:focus-visible,
+.onboarding__secondary:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 35px rgba(37, 99, 235, 0.15);
+}
+
 .app {
   width: min(960px, 100%);
   display: grid;

--- a/tests/moq-dual.spec.ts
+++ b/tests/moq-dual.spec.ts
@@ -98,7 +98,7 @@ test.describe("MoQ transport remote playback", () => {
     const pageA = await ctxA.newPage();
     const pageB = await ctxB.newPage();
 
-    const base = `/?transport=moq&relay=${encodeURIComponent(RELAY_URL)}&room=${ROOM_NAME}`;
+    const base = `/${ROOM_NAME}?transport=moq&relay=${encodeURIComponent(RELAY_URL)}`;
 
     await pageA.goto(`${base}&name=ClientA`);
     await pageB.goto(`${base}&name=ClientB`);

--- a/tests/preview.spec.ts
+++ b/tests/preview.spec.ts
@@ -27,19 +27,16 @@ test.describe("mock meeting sandbox", () => {
     });
   });
 
-  test("hides mock controls by default", async ({ page }) => {
-    await page.goto("/?transport=mock");
+  test("shows onboarding page", async ({ page }) => {
+    await page.goto("/");
 
-    const localVideo = page.locator('[data-participant-id="local"] video');
-    await expect(localVideo).toBeVisible();
-
-    await expect(page.getByRole("button", { name: /Mark remote as speaking/i })).toHaveCount(0);
-    await expect(page.getByRole("button", { name: /Add mock remote/i })).toHaveCount(0);
-    await expect(page.locator('[data-kind="remote"]')).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: /Start a meeting/i })).toBeVisible();
+    await expect(page.getByLabel(/Meeting name/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: /Start meeting/i })).toBeVisible();
   });
 
   test("renders local preview and responds to UI interactions", async ({ page }) => {
-    await page.goto("/?mockControls=1&transport=mock");
+    await page.goto("/mock-room?mockControls=1&transport=mock");
 
     const localVideo = page.locator('[data-participant-id="local"] video');
     await expect(localVideo).toBeVisible();


### PR DESCRIPTION
## Summary
- add a simple onboarding screen at `/` to choose or regenerate a meeting name
- route meeting pages to `/<meeting-name>` and fall back to the onboarding screen when no room is provided
- update styles for a clean white onboarding card and adjust tests to navigate via the new paths

## Testing
- npm run build
- npm run test:e2e
- nix run .#ci